### PR TITLE
Read-only field

### DIFF
--- a/service/controllers/logs.controller.js
+++ b/service/controllers/logs.controller.js
@@ -44,7 +44,10 @@ export async function ListLogs(req, res) {
 }
 
 export function GetLog(req, res) {
-	res.json(req.logEntry.toCleanJSON());
+	res.json({
+		...req.logEntry.toCleanJSON(),
+		readOnly: req.readOnlyResource
+	});
 }
 
 export async function CreateLogs(req, res) {

--- a/service/controllers/profiles.controller.js
+++ b/service/controllers/profiles.controller.js
@@ -38,7 +38,8 @@ export async function GetProfile(req, res) {
 		res.json({
 			...req.account.getProfileJSON(),
 			bottomTimeLogged,
-			divesLogged
+			divesLogged,
+			readOnly: req.readOnlyResource
 		});
 	} catch (err) {
 		const logId = req.logError('Failed to retrieve profile information.', err);
@@ -51,6 +52,7 @@ export async function UpdateProfile(req, res) {
 		delete req.body.memberSince;
 		delete req.body.divesLogged;
 		delete req.body.bottomTimeLogged;
+		delete req.body.readOnly;
 
 		const isValid = Joi.validate(req.body, UpdateProfileSchema);
 		if (isValid.error) {

--- a/service/controllers/security.controller.js
+++ b/service/controllers/security.controller.js
@@ -26,10 +26,12 @@ export async function RetrieveUserAccount(req, res, next) {
 
 export function AssertUserReadPermission(req, res, next) {
 	if (req.user && (req.user.role === 'admin' || req.user.id === req.account.id)) {
+		req.readOnlyResource = false;
 		return next();
 	}
 
 	if (req.account.logsVisibility === 'public') {
+		req.readOnlyResource = true;
 		return next();
 	}
 
@@ -50,5 +52,6 @@ export function AssertUserWritePermission(req, res, next) {
 			forbiddenMessage);
 	}
 
+	req.readOnlyResource = false;
 	next();
 }

--- a/tests/log-entries/controller.tests.js
+++ b/tests/log-entries/controller.tests.js
@@ -50,6 +50,7 @@ describe('Logs Controller', () => {
 
 			expect(res.body).to.exist;
 			fake.entryId = res.body.entryId;
+			fake.readOnly = false;
 			expect(res.body).to.eql(fake);
 		});
 
@@ -197,6 +198,7 @@ describe('Logs Controller', () => {
 				.set(...user1.authHeader)
 				.expect(200);
 			fake.entryId = entryId;
+			fake.readOnly = false;
 			expect(res.body).to.eql(fake);
 		});
 

--- a/tests/log-entries/security.tests.js
+++ b/tests/log-entries/security.tests.js
@@ -83,6 +83,7 @@ describe('Log Entry Security', () => {
 			const res = await request(App)
 				.get(`/users/${ user1.user.username }/logs/${ entity.id }`)
 				.expect(200);
+			fake.readOnly = true;
 			expect(res.body).to.eql(fake);
 		});
 
@@ -122,6 +123,7 @@ describe('Log Entry Security', () => {
 				.get(`/users/${ user3.user.username }/logs/${ entity.id }`)
 				.set(...admin.authHeader)
 				.expect(200);
+			fake.readOnly = false;
 			expect(res.body).to.eql(fake);
 		});
 
@@ -137,6 +139,7 @@ describe('Log Entry Security', () => {
 				.get(`/users/${ user2.user.username }/logs/${ entity.id }`)
 				.set(...admin.authHeader)
 				.expect(200);
+			fake.readOnly = false;
 			expect(res.body).to.eql(fake);
 		});
 
@@ -152,6 +155,7 @@ describe('Log Entry Security', () => {
 				.get(`/users/${ user3.user.username }/logs/${ entity.id }`)
 				.set(...user3.authHeader)
 				.expect(200);
+			fake.readOnly = false;
 			expect(res.body).to.eql(fake);
 		});
 
@@ -167,6 +171,7 @@ describe('Log Entry Security', () => {
 				.get(`/users/${ user2.user.username }/logs/${ entity.id }`)
 				.set(...user2.authHeader)
 				.expect(200);
+			fake.readOnly = false;
 			expect(res.body).to.eql(fake);
 		});
 
@@ -182,6 +187,7 @@ describe('Log Entry Security', () => {
 				.get(`/users/${ user1.user.username }/logs/${ entity.id }`)
 				.set(...admin.authHeader)
 				.expect(200);
+			fake.readOnly = false;
 			expect(res.body).to.eql(fake);
 		});
 
@@ -197,6 +203,7 @@ describe('Log Entry Security', () => {
 				.get(`/users/${ user1.user.username }/logs/${ entity.id }`)
 				.set(...user2.authHeader)
 				.expect(200);
+			fake.readOnly = true;
 			expect(res.body).to.eql(fake);
 		});
 

--- a/tests/profiles/controller.tests.js
+++ b/tests/profiles/controller.tests.js
@@ -29,7 +29,8 @@ const expectedKeys = [
 	'specialties',
 	'about',
 	'divesLogged',
-	'bottomTimeLogged'
+	'bottomTimeLogged',
+	'readOnly'
 ];
 
 function compareProfiles(result, user) {
@@ -101,6 +102,7 @@ describe('Profiles Controller', () => {
 				.expect(200);
 			expect(result.body).to.exist;
 			expect(result.body).to.have.keys(expectedKeys);
+			expect(result.body.readOnly).to.be.false;
 			compareProfiles(result.body, privateUser.user);
 		});
 
@@ -110,6 +112,7 @@ describe('Profiles Controller', () => {
 				.set(...privateUser.authHeader)
 				.expect(200);
 			expect(result.body).to.exist;
+			expect(result.body.readOnly).to.be.true;
 			expect(result.body).to.have.keys(expectedKeys);
 			compareProfiles(result.body, publicUser.user);
 		});
@@ -142,6 +145,7 @@ describe('Profiles Controller', () => {
 				.set(...adminUser.authHeader)
 				.expect(200);
 			expect(result.body).to.exist;
+			expect(result.body.readOnly).to.false;
 			expect(result.body).to.have.keys(expectedKeys);
 			compareProfiles(result.body, publicUser.user);
 		});
@@ -156,6 +160,7 @@ describe('Profiles Controller', () => {
 				.set(...adminUser.authHeader)
 				.expect(200);
 			expect(result.body).to.exist;
+			expect(result.body.readOnly).to.false;
 			expect(result.body).to.have.keys(expectedKeys);
 			compareProfiles(result.body, friendsOnlyUser.user);
 		});
@@ -166,6 +171,7 @@ describe('Profiles Controller', () => {
 				.set(...adminUser.authHeader)
 				.expect(200);
 			expect(result.body).to.exist;
+			expect(result.body.readOnly).to.false;
 			expect(result.body).to.have.keys(expectedKeys);
 			compareProfiles(result.body, privateUser.user);
 		});
@@ -175,6 +181,7 @@ describe('Profiles Controller', () => {
 				.get(`/users/${ publicUser.user.username }/profile`)
 				.expect(200);
 			expect(result.body).to.exist;
+			expect(result.body.readOnly).to.true;
 			expect(result.body).to.have.keys(expectedKeys);
 			compareProfiles(result.body, publicUser.user);
 		});
@@ -330,6 +337,7 @@ describe('Profiles Controller', () => {
 			const fake = fakeProfile();
 			const oldCreatedAt = publicUser.user.createdAt;
 			fake.memberSince = moment().utc().toDate();
+			fake.readOnly = false;
 
 			await request(App)
 				.patch(`/users/${ publicUser.user.username }/profile`)


### PR DESCRIPTION
Log entries and profiles are now returned with a `readOnly` field which can be used to indicate whether the current user has permission to modify the resource.