### PR TITLE
Friends API bug fixes

### DIFF
--- a/docs/Friends.md
+++ b/docs/Friends.md
@@ -76,7 +76,7 @@ HTTP Status Code | Details
 **409 Conflict** | The request was rejected because the friend request already exists.
 **500 Server Error** | An internal server error occurred. Log information will be provided in the [Error](General.md#error-object) object for troubleshooting.
 
-### POST /users/:username/:friends/[approve|reject]
+### POST /users/:username/friends/:friendName/[approve|reject]
 These routes can approve or reject a friend request, respectively. If the request is approved, then both
 users will become "friends" with each other. (That is, a reciprocal friendship will be created under the
 new friend's account.) The route must actually be called by the "friend" and not the user, which is a

--- a/package-lock.json
+++ b/package-lock.json
@@ -5420,9 +5420,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/service/controllers/friends.controller.js
+++ b/service/controllers/friends.controller.js
@@ -67,10 +67,26 @@ export async function CreateFriendRequest(req, res, next) {
 			return badRequest('Users cannot be friends with themselves', null, res);
 		}
 
-		let friendRequest = await Friend.findOne({
-			user: req.account.username,
-			friend: req.friend.username
-		});
+		let friendRequest = null;
+		let incomingRequest = null;
+		[ friendRequest, incomingRequest ] = await Promise.all([
+			Friend.findOne({
+				user: req.account.username,
+				friend: req.friend.username
+			}),
+			Friend.findOne({
+				user: req.friend.username,
+				friend: req.account.username
+			})
+		]);
+
+		if (incomingRequest) {
+			return conflict(
+				res,
+				'friend',
+				'A reciprocal friend-request already exists.'
+			);
+		}
 
 		if (friendRequest) {
 			if (friendRequest.approved === false) {
@@ -184,7 +200,19 @@ export async function ApproveFriendRequest(req, res) {
 		req.friendRequest.approved = true;
 		req.friendRequest.evaluatedOn = new Date();
 		req.friendRequest.reason = req.body.reason;
-		await req.friendRequest.save();
+
+		const reciprocal = new Friend({
+			user: req.friendRequest.friend,
+			friend: req.friendRequest.user,
+			requestedOn: req.friendRequest.requestedOn,
+			evaluatedOn: req.friendRequest.evaluatedOn,
+			approved: true
+		});
+
+		await Promise.all([
+			req.friendRequest.save(),
+			reciprocal.save()
+		]);
 	} catch (err) {
 		const logId = req.logError(
 			`Failed to approve friend request from ${ req.params.username } to ${ req.params.friendName }.`,

--- a/tests/friends/controller.tests.js
+++ b/tests/friends/controller.tests.js
@@ -327,6 +327,27 @@ describe('Friends controller', () => {
 			expect(templateSpy.called).to.be.false;
 		});
 
+		it('Will return a 409 if a reciprocal friend request already exists', async () => {
+			const friendRequest = new Friend({
+				friend: user.user.username,
+				user: friends[0].username,
+				requestedOn: new Date()
+			});
+
+			await friendRequest.save();
+
+			templateSpy = sinon.spy(templates, 'NewFriendRequestEmail');
+			mailerSpy = sinon.spy(mailer, 'sendMail');
+
+			await request(App)
+				.put(`/users/${ user.user.username }/friends/${ friends[0].username }`)
+				.set(...user.authHeader)
+				.expect(409);
+
+			expect(mailerSpy.called).to.be.false;
+			expect(templateSpy.called).to.be.false;
+		});
+
 		it('Will simply replace a previously-rejected request', async () => {
 			templateSpy = sinon.spy(templates, 'NewFriendRequestEmail');
 			mailerSpy = sinon.spy(mailer, 'sendMail');
@@ -465,6 +486,28 @@ describe('Friends controller', () => {
 			expect(mailOptions.from).to.not.exist;
 			expect(mailOptions.subject).to.equal('Dive Buddy Request Accepted');
 			expect(mailOptions.html).to.exist;
+		});
+
+		it('Will also create a reciprocal friendship', async () => {
+			const friendRequest = new Friend({
+				user: user.user.username,
+				friend: friends[0].username,
+				requestedOn: new Date()
+			});
+			await friendRequest.save();
+
+			await request(App)
+				.post(`/users/${ user.user.username }/friends/${ friends[0].username }/approve`)
+				.set(...friendAuthHeader)
+				.expect(204);
+
+			const result = await Friend.findOne({
+				friend: user.user.username,
+				user: friends[0].username
+			});
+			expect(result).to.exist;
+			expect(result.approved).to.be.true;
+			expect(result.evaluatedOn).to.exist;
 		});
 
 		it('Will return 400 if the request has already been approved', async () => {


### PR DESCRIPTION
* Error in documentation (Issue #55)
* Friend request approvals now make a reciprocal friend record (Issue #56)
* Friend requests can no longer be created if the user has already received a friend request from the other user.