### PR TITLE
Re-worked how air tanks get logged in log entries.

### DIFF
--- a/docs/LogEntries.md
+++ b/docs/LogEntries.md
@@ -36,7 +36,7 @@ Describes a single log entry from a user's log book.
 			"in": "Number: The amount of air (in bar) in the cylinder(s) when entering the water.",
 			"out": "Number: The amount of air (in bar) in the cylinder(s) when exiting the water.",
 			"count": "Number: Number of tanks worn (1 = single, 2 = doubles, etc.)",
-			"name": "String: Name description of the tank. (E.g. HP100)",
+			"name": "String: Name description of the tank. (E.g. HP100.) Max 200 characters.",
 			"size": "Number: Volume of the tank(s) in litres.",
 			"workingPressure": "Number: Rated working pressure of the tank(s) in bar.",
 			"material": "String: The material the tank(s) are made of. (One of 'al' or 'fe'.)",
@@ -77,10 +77,12 @@ Describes a single log entry from a user's log book.
 The `gps`, `air`, `decoStops`, `temperature`, `tags` and `weight` nested objects are all considered
 optional.
 
-The value of `air.out` cannot exceed that of `air.in`. Attempting this will cause a validation error.
+The `air` array can contain from 0 to 20 entries representing the different cylinders used on the dive. If
+joined cylinders are used (i.e. doubles/twins) where a single SPG shows the pressure for both tanks then
+they should be entered as a single air entry with the `count` property set appropriately. (E.g. 2 for
+doubles.)
 
-The `air.volume` and `air.volumeUnit` values must be supplied together. Both can be omitted but if one is
-missing and the other is present, it will cause a validation error.
+The value of `air.out` cannot exceed that of `air.in`. Attempting this will cause a validation error.
 
 The `decoStops` array can contain from 0 to 15 depth/duration tuples representing each of the
 decompression stops. The stops should be ordered chronologically (i.e. deepest to shallowest.)

--- a/docs/LogEntries.md
+++ b/docs/LogEntries.md
@@ -31,16 +31,19 @@ Describes a single log entry from a user's log book.
 	"surfaceInterval": "Number: Duration in minutes of the surface interval taken before this dive",
 	"averageDepth": "Number: Average depth in meters",
 	"maxDepth": "REQUIRED Number: Maximum depth in meters (must be >= 'averageDepth')",
-	"air": {
-		"in": "Number: The amount of air (in bar) in the cylinder(s) when entering the water.",
-		"out": "Number: The amount of air (in bar) in the cylinder(s) when exiting the water.",
-		"doubles": "Boolean: True if the dive was done with doubles (or sidemount.)",
-		"volume": "Number: Volume of the tank(s) in litres or cubic feet.",
-		"volumeUnit": "String: Unit used to measure the volume of the cylinder. (One of 'L' or 'cf'.)",
-		"material": "String: The material the tank(s) are made of. (One of 'aluminum' or 'steel'.)",
-		"oxygen": "Number: The % oxygen content of the breathing gas. (1-100%.)",
-		"helium": "Number: The % helium content of the breathing gas. (0-95%.)"
-	},
+	"air": [
+		{
+			"in": "Number: The amount of air (in bar) in the cylinder(s) when entering the water.",
+			"out": "Number: The amount of air (in bar) in the cylinder(s) when exiting the water.",
+			"count": "Number: Number of tanks worn (1 = single, 2 = doubles, etc.)",
+			"name": "String: Name description of the tank. (E.g. HP100)",
+			"size": "Number: Volume of the tank(s) in litres.",
+			"workingPressure": "Number: Rated working pressure of the tank(s) in bar.",
+			"material": "String: The material the tank(s) are made of. (One of 'al' or 'fe'.)",
+			"oxygen": "Number: The % oxygen content of the breathing gas. (1-100%.)",
+			"helium": "Number: The % helium content of the breathing gas. (0-95%.)"
+		}
+	],
 	"decoStops": [
 		{
 			"depth": "REQUIRED Number: The depth (in meters) that the stop was made at. (Must be positive.)",

--- a/service/data/log-entry.js
+++ b/service/data/log-entry.js
@@ -24,16 +24,19 @@ const logEntrySchema = mongoose.Schema({
 	surfaceInterval: Number,
 	maxDepth: Number,
 	averageDepth: Number,
-	air: {
-		in: Number,
-		out: Number,
-		doubles: Boolean,
-		volume: Number,
-		volumeUnit: String,
-		material: String,
-		oxygen: Number,
-		helium: Number
-	},
+	air: [
+		{
+			in: Number,
+			out: Number,
+			count: Number,
+			name: String,
+			size: Number,
+			workingPressure: Number,
+			material: String,
+			oxygen: Number,
+			helium: Number
+		}
+	],
 	decoStops: [
 		{
 			depth: Number,
@@ -79,6 +82,20 @@ logEntrySchema.methods.toCleanJSON = function () {
 		clean.decoStops = clean.decoStops.map(ds => ({
 			depth: ds.depth,
 			duration: ds.duration
+		}));
+	}
+
+	if (clean.air) {
+		clean.air = clean.air.map(a => ({
+			in: a.in,
+			out: a.out,
+			count: a.count,
+			name: a.name,
+			size: a.size,
+			workingPressure: a.workingPressure,
+			material: a.material,
+			oxygen: a.oxygen,
+			helium: a.helium
 		}));
 	}
 

--- a/service/validation/log-entry.js
+++ b/service/validation/log-entry.js
@@ -35,7 +35,7 @@ const logEntryBaseSchema = {
 					otherwise: Joi.number().positive()
 				}
 			).allow(null),
-			count: Joi.number().positive().max(10).allow(null),
+			count: Joi.number().integer().positive().max(10).allow(null),
 			name: Joi.string().max(200).allow(null),
 			size: Joi.number().positive().allow(null),
 			workingPressure: Joi.number().positive().allow(null),

--- a/service/validation/log-entry.js
+++ b/service/validation/log-entry.js
@@ -24,23 +24,26 @@ const logEntryBaseSchema = {
 		longitude: Joi.number().min(-180.0).max(180.0).required()
 	}),
 
-	air: Joi.object().keys({
-		in: Joi.number().positive().allow(null),
-		out: Joi.when(
-			'in',
-			{
-				is: Joi.exist(),
-				then: Joi.number().positive().max(Joi.ref('in')),
-				otherwise: Joi.number().positive()
-			}
-		).allow(null),
-		doubles: Joi.boolean().allow(null),
-		volume: Joi.number().positive().allow(null),
-		volumeUnit: Joi.string().only([ 'L', 'cf' ]).allow(null),
-		material: Joi.string().only([ 'aluminum', 'steel' ]).allow(null),
-		oxygen: Joi.number().positive().max(100).allow(null),
-		helium: Joi.number().min(0).max(95).allow(null)
-	}).and('volume', 'volumeUnit'),
+	air: Joi.array().items(
+		Joi.object().keys({
+			in: Joi.number().positive().allow(null),
+			out: Joi.when(
+				'in',
+				{
+					is: Joi.exist(),
+					then: Joi.number().positive().max(Joi.ref('in')),
+					otherwise: Joi.number().positive()
+				}
+			).allow(null),
+			count: Joi.number().positive().max(10).allow(null),
+			name: Joi.string().max(200).allow(null),
+			size: Joi.number().positive().allow(null),
+			workingPressure: Joi.number().positive().allow(null),
+			material: Joi.string().only([ 'al', 'fe', null ]),
+			oxygen: Joi.number().positive().max(100).allow(null),
+			helium: Joi.number().min(0).max(95).allow(null)
+		})
+	).max(20).allow(null),
 
 	decoStops: Joi.array().items(
 		Joi.object().keys({

--- a/tests/log-entries/validation.tests.js
+++ b/tests/log-entries/validation.tests.js
@@ -403,6 +403,11 @@ describe('Log entry validation', () => {
 			validateCreate('number.positive');
 		});
 
+		it('Air count must be an integer', () => {
+			logEntry.air[0].count = 1.5;
+			validateCreate('number.integer');
+		});
+
 		it('Air count cannot be greater than 10', () => {
 			logEntry.air[0].count = 11;
 			validateCreate('number.max');

--- a/tests/log-entries/validation.tests.js
+++ b/tests/log-entries/validation.tests.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import fakeLogEntry from '../util/fake-log-entry';
+import fakeLogEntryAir from '../util/fake-log-entry-air';
 import fakeMongoId from '../util/fake-mongo-id';
 import faker from 'faker';
 import Joi from 'joi';
@@ -328,148 +329,209 @@ describe('Log entry validation', () => {
 	});
 
 	describe('Air', () => {
+		it('Air is optional', () => {
+			delete logEntry.air;
+			validateCreate();
+		});
+
+		it('Air array can be null', () => {
+			logEntry.air = null;
+			validateCreate();
+		});
+
+		it('Air array cannot have more than 20 entries', () => {
+			const airEntries = new Array(21);
+			for (let i = 0; i < airEntries.length; i++) {
+				airEntries[i] = fakeLogEntryAir();
+			}
+			logEntry.air = airEntries;
+			validateCreate('array.max');
+		});
+
+		it('Air array can be empty', () => {
+			logEntry.air = [];
+			validateCreate();
+		});
+
 		it('Air in is optional', () => {
-			delete logEntry.air.in;
+			delete logEntry.air[0].in;
 			validateCreate();
 		});
 
 		it('Air in must be a number', () => {
-			logEntry.air.in = 'seven';
+			logEntry.air[0].in = 'seven';
 			validateCreate('number.base');
 		});
 
 		it('Air in must be positive', () => {
-			logEntry.air.in = 0;
+			logEntry.air[0].in = 0;
 			validateCreate('number.positive');
 		});
 
 		it('Air out is optional', () => {
-			delete logEntry.air.out;
+			delete logEntry.air[0].out;
 			validateCreate();
 		});
 
 		it('Air out must be a number', () => {
-			logEntry.air.out = 'seven';
+			logEntry.air[0].out = 'seven';
 			validateCreate('number.base');
 		});
 
 		it('Air out must be positive', () => {
-			logEntry.air.out = 0;
+			logEntry.air[0].out = 0;
 			validateCreate('number.positive');
 		});
 
 		it('Air out must be less than air in', () => {
-			logEntry.air.out = logEntry.air.in + 5;
+			logEntry.air[0].out = logEntry.air[0].in + 5;
 			validateCreate('number.max');
 		});
 
-		it('Air doubles is optional', () => {
-			delete logEntry.air.doubles;
+		it('Air count is optional', () => {
+			delete logEntry.air[0].count;
 			validateCreate();
 		});
 
-		it('Air doubles must be a boolean', () => {
-			logEntry.air.doubles = 'yup';
-			validateCreate('boolean.base');
-		});
-
-		it('Air volume is optional', () => {
-			delete logEntry.air.volume;
-			delete logEntry.air.volumeUnit;
-			validateCreate();
-		});
-
-		it('Air volume must be a number', () => {
-			logEntry.air.volume = 'pony-bottle';
+		it('Air count must be a number', () => {
+			logEntry.air[0].count = 'doubles';
 			validateCreate('number.base');
 		});
 
-		it('Air volume must be positive', () => {
-			logEntry.air.volume = 0;
+		it('Air count must be positive', () => {
+			logEntry.air[0].count = 0;
 			validateCreate('number.positive');
 		});
 
-		it('Air volume unit is required if air volume is supplied', () => {
-			delete logEntry.air.volumeUnit;
-			validateCreate('object.and');
+		it('Air count cannot be greater than 10', () => {
+			logEntry.air[0].count = 11;
+			validateCreate('number.max');
 		});
 
-		it('Air volume is required if air volume unit is supplied', () => {
-			delete logEntry.air.volume;
-			validateCreate('object.and');
-		});
-
-		[ 'L', 'cf' ].forEach(u => {
-			it(`Air volume unit can be set to ${ u }`, () => {
-				logEntry.air.volumeUnit = u;
-				validateCreate();
-			});
-		});
-
-		it('Air volume unit cannot be an invalid value', () => {
-			logEntry.air.volumeUnit = 'm3';
-			validateCreate('any.allowOnly');
-		});
-
-		it('Air tank material is optional', () => {
-			delete logEntry.air.material;
+		it('Air name is optional', () => {
+			delete logEntry.air[0].name;
 			validateCreate();
 		});
 
-		[ 'aluminum', 'steel' ].forEach(m => {
-			it(`Air tank material can be set to ${ m }`, () => {
-				logEntry.air.material = m;
+		it('Air name must be a string', () => {
+			logEntry.air[0].name = 767;
+			validateCreate('string.base');
+		});
+
+		it('Air name cannot be empty', () => {
+			logEntry.air[0].name = '';
+			validateCreate('any.empty');
+		});
+
+		it('Air name can be null', () => {
+			logEntry.air[0].name = null;
+			validateCreate();
+		});
+
+		it('Air name cannot be longer than 200 characters', () => {
+			logEntry.air[0].name = faker.lorem.sentences(10).substr(0, 201);
+			validateCreate('string.max');
+		});
+
+		it('Air size is optional', () => {
+			delete logEntry.air[0].size;
+			validateCreate();
+		});
+
+		it('Air size can be null', () => {
+			logEntry.air[0].size = null;
+			validateCreate();
+		});
+
+		it('Air size must be a number', () => {
+			logEntry.air[0].size = '11.1L';
+			validateCreate('number.base');
+		});
+
+		it('Air size must be positive', () => {
+			logEntry.air[0].size = 0;
+			validateCreate('number.positive');
+		});
+
+		it('Air working pressure is optional', () => {
+			delete logEntry.air[0].workingPressure;
+			validateCreate();
+		});
+
+		it('Air working pressure can be null', () => {
+			logEntry.air[0].workingPressure = null;
+			validateCreate();
+		});
+
+		it('Air working pressure must be a number', () => {
+			logEntry.air[0].workingPressure = '3000psi';
+			validateCreate('number.base');
+		});
+
+		it('Air working pressure must be positive', () => {
+			logEntry.air[0].workingPressure = 0;
+			validateCreate('number.positive');
+		});
+
+		it('Air tank material is optional', () => {
+			delete logEntry.air[0].material;
+			validateCreate();
+		});
+
+		[ 'al', 'fe', null ].forEach(m => {
+			it(`Air tank material can be set to "${ m }"`, () => {
+				logEntry.air[0].material = m;
 				validateCreate();
 			});
 		});
 
 		it('Air tank material cannot be set to an invalid value', () => {
-			logEntry.air.material = 'adamantium';
+			logEntry.air[0].material = 'adamantium';
 			validateCreate('any.allowOnly');
 		});
 
 		it('Oxygen content is optional', () => {
-			delete logEntry.air.oxygen;
+			delete logEntry.air[0].oxygen;
 			validateCreate();
 		});
 
 		it('Oxygen content must be a number', () => {
-			logEntry.air.oxygen = 'hyperoxic';
+			logEntry.air[0].oxygen = 'hyperoxic';
 			validateCreate('number.base');
 		});
 
 		it('Oxygen content must be positive', () => {
-			logEntry.air.oxygen = 0;
+			logEntry.air[0].oxygen = 0;
 			validateCreate('number.positive');
 		});
 
 		it('Oxygen content cannot exceed 100%', () => {
-			logEntry.air.oxygen = 100.6;
+			logEntry.air[0].oxygen = 100.6;
 			validateCreate('number.max');
 		});
 
 		it('Helium content is optional', () => {
-			delete logEntry.air.helium;
+			delete logEntry.air[0].helium;
 			validateCreate();
 		});
 
 		it('Helium content must be a number', () => {
-			logEntry.air.helium = 'lots';
+			logEntry.air[0].helium = 'lots';
 			validateCreate('number.base');
 		});
 
 		it('Helium content can be zero', () => {
-			logEntry.air.helium = 0;
+			logEntry.air[0].helium = 0;
 			validateCreate();
 		});
 
 		it('Helium content cannot be negative', () => {
-			logEntry.air.helium = -0.5;
+			logEntry.air[0].helium = -0.5;
 			validateCreate('number.min');
 		});
 
 		it('Helium cannot exceed 95%', () => {
-			logEntry.air.helium = 95.3;
+			logEntry.air[0].helium = 95.3;
 			validateCreate('number.max');
 		});
 	});

--- a/tests/profiles/controller.tests.js
+++ b/tests/profiles/controller.tests.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { App } from '../../service/server';
 import createFakeAccount from '../util/create-fake-account';
 import { ErrorIds } from '../../service/utils/error-response';
@@ -84,8 +83,7 @@ describe('Profiles Controller', () => {
 		for (let i = 0; i < logEntries.length; i++) {
 			logEntries[i] = fakeLogEntry(publicUser.user.id);
 		}
-
-		await Promise.all(_.map(logEntries, e => new LogEntry(e).save()));
+		await LogEntry.insertMany(logEntries.map(e => new LogEntry(e)));
 	});
 
 	afterEach(() => {

--- a/tests/util/fake-log-entry-air.js
+++ b/tests/util/fake-log-entry-air.js
@@ -1,0 +1,18 @@
+import faker from 'faker';
+import TankProperties from '../../service/utils/tank-properties';
+
+export default () => {
+	const tankProfile = faker.random.arrayElement(Object.keys(TankProperties));
+
+	return {
+		in: faker.random.number({ min: 200, max: 215 }),
+		out: faker.random.number({ min: 32, max: 40 }),
+		count: faker.random.arrayElement([ 1, 2 ]),
+		name: tankProfile,
+		size: TankProperties[tankProfile].size,
+		workingPressure: TankProperties[tankProfile].workingPressure,
+		material: TankProperties[tankProfile].material,
+		oxygen: faker.random.number({ min: 21, max: 40 }),
+		helium: 0
+	};
+};

--- a/tests/util/fake-log-entry.js
+++ b/tests/util/fake-log-entry.js
@@ -1,3 +1,4 @@
+import fakeLogEntryAir from './fake-log-entry-air';
 import faker from 'faker';
 
 let diveNumber = 1;
@@ -46,16 +47,7 @@ export default userId => {
 		site: faker.fake('{{address.cityPrefix}} {{name.lastName}}'),
 		averageDepth,
 		maxDepth,
-		air: {
-			in: faker.random.number({ min: 200, max: 215 }),
-			out: faker.random.number({ min: 32, max: 40 }),
-			doubles: faker.random.boolean(),
-			volume: faker.random.arrayElement([ 40, 80, 100, 120 ]),
-			volumeUnit: 'cf',
-			material: faker.random.arrayElement([ 'aluminum', 'steel' ]),
-			oxygen: faker.random.number({ min: 21, max: 40 }),
-			helium: 0
-		},
+		air: [ fakeLogEntryAir() ],
 		decoStops: [
 			{
 				depth: 3,


### PR DESCRIPTION
Air in log entries is stored in a much more logical way.
* Tank sizes are now stored in terms of size (L) and working pressure (bar). This will help in calculating RMV rates for users.
* Doubles (boolean) is now Count (Number) so divers can specify triples or even quadruples (or more!)
* Air section is now an array so technical divers can list all of their air bottles independently.