### PR TITLE
Rearranged how weight gets recorded.

### DIFF
--- a/docs/LogEntries.md
+++ b/docs/LogEntries.md
@@ -61,7 +61,11 @@ Describes a single log entry from a user's log book.
 		]
 	},
 	"weight": {
-		"amount": "Number: Amount of weight worn in kilograms. (Must be zero or more.)",
+		"belt": "Number: Amount of weight worn on the weight belt (kilograms).",
+		"integrated": "Number: Amount of weight worn in the BCD's integrated pockets (kilograms).",
+		"backplate": "Number: Amount of weight worn in trim pockets or on the backplate (kilograms).",
+		"ankles": "Number: Amount of weight worn on the ankles (kilograms).",
+		"other": "Number: Amount of weight worn anywhere else - tank neck, clipped to BCD, etc. (kilograms).",
 		"correctness": "String: Indication of how good the weight was. (One of 'good', 'too much' or 'too little')",
 		"trim": "String: Indication of how good the trim was. (One of 'good', 'feet down' or 'feet up'.)"
 	},

--- a/service/data/log-entry.js
+++ b/service/data/log-entry.js
@@ -44,7 +44,11 @@ const logEntrySchema = mongoose.Schema({
 		}
 	],
 	weight: {
-		amount: Number,
+		belt: Number,
+		integrated: Number,
+		backplate: Number,
+		ankles: Number,
+		other: Number,
 		correctness: String,
 		trim: String
 	},

--- a/service/validation/log-entry.js
+++ b/service/validation/log-entry.js
@@ -63,7 +63,11 @@ const logEntryBaseSchema = {
 
 	// Weighting
 	weight: Joi.object().keys({
-		amount: Joi.number().min(0).allow(null),
+		belt: Joi.number().min(0).allow(null),
+		integrated: Joi.number().min(0).allow(null),
+		backplate: Joi.number().min(0).allow(null),
+		ankles: Joi.number().min(0).allow(null),
+		other: Joi.number().min(0).allow(null),
 		correctness: Joi.string().only([ 'good', 'too little', 'too much', null ]),
 		trim: Joi.string().only([ 'good', 'feet down', 'feet up', null ])
 	}),

--- a/tests/log-entries/controller.tests.js
+++ b/tests/log-entries/controller.tests.js
@@ -330,7 +330,7 @@ describe('Logs Controller', () => {
 			delete fakes[1].userId;
 			delete fakes[2].userId;
 
-			fakes[0].weight = { amount: 69.4 };
+			fakes[0].weight = { backplate: 12.5 };
 			fakes[1].maxDepth = 300;
 			fakes[2].site = 'Local swimming pool';
 
@@ -366,7 +366,7 @@ describe('Logs Controller', () => {
 			delete fakes[1].userId;
 			delete fakes[2].userId;
 
-			fakes[0].weight = { amount: 69.4 };
+			fakes[0].weight = { integrated: 6.2 };
 			fakes[1].maxDepth = 300;
 			fakes[2].site = 'Local swimming pool';
 
@@ -503,7 +503,7 @@ describe('Logs Controller', () => {
 			delete fakes[1].userId;
 			delete fakes[2].userId;
 
-			fakes[0].weight = { amount: 69.4 };
+			fakes[0].weight = { belt: 2.8 };
 			fakes[1].maxDepth = 300;
 			fakes[2].site = 'Local swimming pool';
 

--- a/tests/log-entries/validation.tests.js
+++ b/tests/log-entries/validation.tests.js
@@ -542,24 +542,31 @@ describe('Log entry validation', () => {
 	});
 
 	describe('Weight', () => {
-		it('Amount is optional', () => {
-			delete logEntry.weight.amount;
-			validateCreate();
-		});
+		[ 'belt', 'integrated', 'backplate', 'ankles', 'other' ].forEach(field => {
+			it(`${ field } weight is optional`, () => {
+				delete logEntry.weight[field];
+				validateCreate();
+			});
 
-		it('Amount must be a number', () => {
-			logEntry.weight.amount = 'not much';
-			validateCreate('number.base');
-		});
+			it(`${ field } weight can be null`, () => {
+				logEntry.weight[field] = null;
+				validateCreate();
+			});
 
-		it('Amount can be zero', () => {
-			logEntry.weight.amount = 0;
-			validateCreate();
-		});
+			it(`${ field } weight must be a number`, () => {
+				logEntry.weight[field] = '6kg';
+				validateCreate('number.base');
+			});
 
-		it('Amount cannot be negative', () => {
-			logEntry.weight.amount = -0.5;
-			validateCreate('number.min');
+			it(`${ field } weight can be zero`, () => {
+				logEntry.weight[field] = 0;
+				validateCreate();
+			});
+
+			it(`${ field } weight cannot be negative`, () => {
+				logEntry.weight[field] = -0.5;
+				validateCreate('number.min');
+			});
 		});
 
 		it('Correctness is optional', () => {

--- a/tests/util/fake-log-entry.js
+++ b/tests/util/fake-log-entry.js
@@ -59,7 +59,10 @@ export default userId => {
 			longitude: faker.random.number({ min: -180.0, max: 180.0 })
 		},
 		weight: {
-			amount: faker.random.number({ min: 2, max: 19 }),
+			belt: faker.random.number({ min: 0, max: 27 }) / 10,
+			integrated: faker.random.number({ min: 0, max: 27 }) / 10,
+			backplate: faker.random.number({ min: 0, max: 45 }) / 10,
+			ankles: faker.random.number({ min: 0, max: 90 }) / 100,
 			correctness: faker.random.arrayElement([ 'good', 'too little', 'too much' ]),
 			trim: faker.random.arrayElement([ 'good', 'feet down', 'feet up' ])
 		},


### PR DESCRIPTION
Removed the `weight.amount` field in the log entry schema and broke it into more specific fields: `belt`, `integrated`, `backplate`, `ankles`, and `other`.