### PR TITLE
Dive site timestamps

### DIFF
--- a/docs/Sites.md
+++ b/docs/Sites.md
@@ -78,7 +78,7 @@ be a number between `1.0` and `5.0`.
 * **owner** - Only show dive sites submitted by specified specified user.
 * **sortOrder** - The order in which results are returned. Must be `asc` or `desc`. (The default is `asc`.)
 * **sortBy** - The field on which to sort the results. Valid values are `relevance` (the default),
-`difficulty`, and `rating`.
+`difficulty`, `modified`, and `rating`.
 
 **Notes:** If `distance` is supplied then `closeTo` is required. Supplying `distance` without `closeTo`
 will result in a 400 Bad Request error.

--- a/docs/Sites.md
+++ b/docs/Sites.md
@@ -25,11 +25,13 @@ Describes a dive site.
 	"gps": {
 		"lon": "REQUIRED Number: Longitude of the dive site. Must be between -180.0 and 180.0.",
 		"lat": "REQUIRED Number: Latitude of the dive site. Must be between -90.0 and 90.0."
-	}
+	},
+  	"created": "String: The time/date at which the dive site entry was first created (ISO string in UTC.)",
+  	"updated": "String: The time/date at which the dive site entry was last modified (ISO string in UTC.)"
 }
 ```
-**Notes:** The `siteId`, `score`, and `owner` properties are ignored when creating and updating dive
-sites. On creation, the site ID will be generated and the owner will be set to the user who created the
+**Notes:** The `siteId`, `score`, `created`, `updated` and `owner` properties are ignored when creating and updating dive
+sites. On creation, the site ID and timestamps will be generated and the owner will be set to the user who created the
 site.
 
 All dive sites are publicly visible. They are meant to be shared among users.
@@ -105,7 +107,7 @@ HTTP Status Code | Details
 Saves new dive sites to the database and indexes them for searching.
 
 #### Message Body
-The message body must be an array of [DiveSite](#divesite-object) objects. The `siteId` and `owner`
+The message body must be an array of [DiveSite](#divesite-object) objects. The `siteId`, `created`, `updated` and `owner`
 properties must be omitted from the objects as these properties are considered read-only. Up to 250
 dive sites can be posted in a single request.
 
@@ -125,7 +127,7 @@ do this.
 * **siteId** - The ID of dive site to be updated.
 
 #### Message Body
-The request body must contain a [DiveSite](#divesite-object) object. The `siteId` and `owner`
+The request body must contain a [DiveSite](#divesite-object) object. The `siteId`, `created`, `updated` and `owner`
 properties must be omitted from the object as these properties are considered read-only.
 
 #### Responses

--- a/service/controllers/logs.controller.js
+++ b/service/controllers/logs.controller.js
@@ -92,7 +92,8 @@ export async function CreateLogs(req, res) {
 			return new LogEntry(e);
 		});
 
-		await Promise.all(_.map(logEntries, entry => entry.save()));
+		await LogEntry.insertMany(logEntries);
+		await LogEntry.esSynchronize();
 		res.status(201).json(logEntries.map(e => e.toCleanJSON()));
 	} catch (err) {
 		const logId = req.logError(

--- a/service/controllers/sites.controller.js
+++ b/service/controllers/sites.controller.js
@@ -121,7 +121,8 @@ export async function searchSites(req, res) {
 
 		searchUtils.addSorting(esQuery, req.query.sortBy, req.query.sortOrder, {
 			difficulty: 'difficulty',
-			rating: 'avgRating'
+			rating: 'avgRating',
+			modified: 'updated'
 		});
 
 		const results = await DiveSite.esSearch(esQuery);
@@ -167,6 +168,8 @@ export async function createSites(req, res) {
 			const site = new DiveSite();
 			site.assign(s);
 			site.owner = req.user.username;
+			site.created = new Date(Date.now());
+			site.updated = new Date(Date.now());
 			return site;
 		});
 
@@ -191,8 +194,8 @@ export async function updateSite(req, res) {
 
 	try {
 		req.diveSite.assign(req.body);
+		req.diveSite.udpated = new Date(Date.now());
 		await req.diveSite.save();
-		await DiveSite.esSynchronize();
 		res.sendStatus(204);
 	} catch (err) {
 		const logId = req.logError('Failed to update dive site info', err);

--- a/service/data/sites.js
+++ b/service/data/sites.js
@@ -23,6 +23,20 @@ const siteSchema = mongoose.Schema({
 		es_type: 'keyword',
 		es_indexed: true
 	},
+	created: {
+		type: Date,
+		required: true,
+		index: true,
+		es_type: 'date',
+		es_indexed: true
+	},
+	updated: {
+		type: Date,
+		required: true,
+		index: true,
+		es_type: 'date',
+		es_indexed: true
+	},
 	location: {
 		type: String,
 		es_indexed: true,
@@ -101,6 +115,9 @@ siteSchema.methods.toCleanJSON = function () {
 			'avgRating'
 		])
 	};
+
+	clean.created = this.created.toISOString();
+	clean.updated = this.updated.toISOString();
 
 	if (this.gps) {
 		clean.gps = {

--- a/service/validation/site.js
+++ b/service/validation/site.js
@@ -38,7 +38,7 @@ export const DiveSiteSearchSchema = Joi.object().keys({
 	distance: Joi.number().positive().max(1000),
 	count: Joi.number().integer().positive().max(1000),
 	skip: Joi.number().integer().min(0),
-	sortBy: Joi.string().valid('relevance', 'difficulty', 'rating'),
+	sortBy: Joi.string().valid('relevance', 'difficulty', 'rating', 'modified'),
 	sortOrder: Joi.string().valid('asc', 'desc')
 }).with('distance', 'closeTo');
 

--- a/tests/dive-sites/controller.tests.js
+++ b/tests/dive-sites/controller.tests.js
@@ -56,11 +56,15 @@ describe('Dive sites controller', () => {
 
 			const [ result ] = body;
 			expect(result.siteId).to.exist;
+			expect(result.created).to.exist;
+			expect(result.updated).to.exist;
 
 			expect(result).to.eql({
 				...fake,
 				owner: userAccount.user.username,
-				siteId: result.siteId
+				siteId: result.siteId,
+				created: result.created,
+				updated: result.updated
 			});
 
 			const entity = await DiveSite.findById(result.siteId);
@@ -84,10 +88,14 @@ describe('Dive sites controller', () => {
 
 			body.forEach((result, i) => {
 				expect(result.siteId).to.exist;
+				expect(result.created).to.exist;
+				expect(result.updated).to.exist;
 				expect(result).to.eql({
 					...fakes[i],
 					owner: userAccount.user.username,
-					siteId: result.siteId
+					siteId: result.siteId,
+					created: result.created,
+					updated: result.updated
 				});
 			});
 
@@ -197,6 +205,8 @@ describe('Dive sites controller', () => {
 				.expect(200);
 
 			fake.siteId = diveSite.id;
+			fake.created = diveSite.created.toISOString();
+			fake.updated = diveSite.updated.toISOString();
 			expect(body).to.eql(fake);
 		});
 
@@ -254,7 +264,9 @@ describe('Dive sites controller', () => {
 				...fake,
 				owner: userAccount.user.username,
 				siteId: diveSite.id,
-				avgRating: diveSite.avgRating
+				avgRating: diveSite.avgRating,
+				created: diveSite.created.toISOString(),
+				updated: diveSite.updated.toISOString()
 			});
 		});
 
@@ -314,7 +326,9 @@ describe('Dive sites controller', () => {
 				...fake,
 				owner: userAccount.user.username,
 				siteId: diveSite.id,
-				avgRating: diveSite.avgRating
+				avgRating: diveSite.avgRating,
+				created: diveSite.created.toISOString(),
+				updated: diveSite.updated.toISOString()
 			});
 		});
 

--- a/tests/dive-sites/searching.tests.js
+++ b/tests/dive-sites/searching.tests.js
@@ -165,7 +165,7 @@ describe('Searching Dive Sites', () => {
 		});
 	});
 
-	[ 'relevance', 'difficulty', 'rating' ].forEach(sortBy => {
+	[ 'relevance', 'difficulty', 'rating', 'modified' ].forEach(sortBy => {
 		[ 'asc', 'desc' ].forEach(sortOrder => {
 			it(`Results can be ordered by ${ sortBy } (${ sortOrder })`, async () => {
 				const count = 25;
@@ -182,7 +182,11 @@ describe('Searching Dive Sites', () => {
 				case 'rating':
 					sortProperty = 'avgRating';
 					break;
+				case 'modified':
+					sortProperty = 'updated';
+					break;
 				default:
+					break;
 				}
 
 				expect(body).to.be.an('array').and.have.lengthOf(count);

--- a/tests/dive-sites/validation.tests.js
+++ b/tests/dive-sites/validation.tests.js
@@ -556,7 +556,7 @@ describe('Dive Site Validation', () => {
 			validateSiteSearch();
 		});
 
-		[ 'relevance', 'difficulty', 'rating' ].forEach(value => {
+		[ 'relevance', 'difficulty', 'rating', 'modified' ].forEach(value => {
 			it(`Sort by can be ${ value }`, () => {
 				siteSearch.sortBy = value;
 				validateSiteSearch();

--- a/tests/log-entries/controller.tests.js
+++ b/tests/log-entries/controller.tests.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { App } from '../../service/server';
 import createAccount from '../util/create-fake-account';
 import mongoose from 'mongoose';
+import { ErrorIds } from '../../service/utils/error-response';
 import { expect } from 'chai';
 import fakeLogEntry, { toLogEntry } from '../util/fake-log-entry';
 import fakeMongoId from '../util/fake-mongo-id';
@@ -9,7 +10,6 @@ import LogEntry from '../../service/data/log-entry';
 import request from 'supertest';
 import sinon from 'sinon';
 import User from '../../service/data/user';
-import { ErrorIds } from '../../service/utils/error-response';
 
 let stub = null;
 
@@ -158,7 +158,7 @@ describe('Logs Controller', () => {
 		it('Will return Server Error if database request fails', async () => {
 			const fake = fakeLogEntry();
 
-			stub = sinon.stub(LogEntry.prototype, 'save');
+			stub = sinon.stub(LogEntry, 'insertMany');
 			stub.rejects('nope');
 
 			const res = await request(App)

--- a/tests/util/fake-dive-site.js
+++ b/tests/util/fake-dive-site.js
@@ -59,7 +59,13 @@ export default userName => {
 
 export function toDiveSite(fake) {
 	const site = new Site();
+	const now = new Date(Date.now());
+	const created = faker.date.past(6, now);
+	const updated = faker.date.between(created, now);
+
 	site.assign(fake);
 	site.owner = fake.owner;
+	site.created = created;
+	site.updated = updated;
 	return site;
 }


### PR DESCRIPTION
Added `created` and `updated` properties to dive sites. These are automatically set by the server. Search results can be sorted on the updated field.